### PR TITLE
Sketch members-service

### DIFF
--- a/services/members-service/Pipfile
+++ b/services/members-service/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/services/members-service/Pipfile.lock
+++ b/services/members-service/Pipfile.lock
@@ -1,0 +1,62 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "a82b674d67d29678775ff6b773de1686a9593749ec14483b0d8e05131b662286"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+            ],
+            "version": "==6.7"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
+                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+            ],
+            "index": "pypi",
+            "version": "==1.0.2"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
+            ],
+            "version": "==0.24"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
+                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+            ],
+            "version": "==2.10"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+            ],
+            "version": "==1.0"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c",
+                "sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b"
+            ],
+            "version": "==0.14.1"
+        }
+    },
+    "develop": {}
+}

--- a/services/members-service/application.py
+++ b/services/members-service/application.py
@@ -1,0 +1,25 @@
+from flask import Flask, request, jsonify
+
+
+application = Flask(__name__)
+
+
+@application.route('/members', methods=['GET', 'POST'])
+def members():
+    if request.method == 'GET':
+        return jsonify([{ 'id': 1, 'name': 'Olga Rios' }, { 'id': 2, 'name': 'Mitchell Simpson' }]), 200
+    elif request.method == 'POST':
+        return jsonify({ 'id': 1, 'name': 'Olga Rios' }), 201
+
+
+@application.route('/members/<int:member_id>', methods=['PUT', 'DELETE'])
+def member(member_id):
+    if request.method == 'PUT':
+        return jsonify({ 'id': member_id, 'name': 'Gwendolyn Carlson' }), 200
+    elif request.method == 'DELETE':
+        return jsonify(None), 204
+
+
+if __name__ == '__main__':
+    application.debug = True
+    application.run(host='0.0.0.0', port='3000')


### PR DESCRIPTION
# What's changed?

Add a skeleton API for the members-service, which will act as a RESTful API. Hard-coded configuration will remain until a follow-up iteration.

For the time being, the API should provide visibility of the data handled by this service and how to consume it, opening room for discussion.

- [x] API
- [ ] Postgresql database
- [ ] Docker
- [ ] Tests
- [ ] Configuration (replacing hard-coded configuration) 
- [ ] Token-based access control
- [ ] Documentation