### PR TITLE
members-service: Allow all cross-origin requests (temporary, until access control is being implemented)

### DIFF
--- a/services/members-service/Pipfile
+++ b/services/members-service/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 flask = "*"
+flask-cors = "*"
 
 [dev-packages]
 

--- a/services/members-service/Pipfile.lock
+++ b/services/members-service/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a82b674d67d29678775ff6b773de1686a9593749ec14483b0d8e05131b662286"
+            "sha256": "3890472530731f0c50bf092eb0abea76e7b92ca13f1d370f9714a0957de35dee"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,14 @@
             "index": "pypi",
             "version": "==1.0.2"
         },
+        "flask-cors": {
+            "hashes": [
+                "sha256:e4c8fc15d3e4b4cce6d3b325f2bab91e0e09811a61f50d7a53493bc44242a4f1",
+                "sha256:ecc016c5b32fa5da813ec8d272941cfddf5f6bba9060c405a70285415cbf24c9"
+            ],
+            "index": "pypi",
+            "version": "==3.0.6"
+        },
         "itsdangerous": {
             "hashes": [
                 "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
@@ -49,6 +57,13 @@
                 "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
             ],
             "version": "==1.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
         },
         "werkzeug": {
             "hashes": [

--- a/services/members-service/application.py
+++ b/services/members-service/application.py
@@ -1,7 +1,11 @@
 from flask import Flask, request, jsonify
+from flask_cors import CORS
 
 
 application = Flask(__name__)
+
+
+CORS(application)
 
 
 @application.route('/members', methods=['GET', 'POST'])


### PR DESCRIPTION
# What's changed?

To allow the `member-management-service` to get all members on page-load, we need to define a cross-origin access policy.

To ease local development, we can allow all cross-origin requests until we are ready to design and implement access control policy for this service, which must be done before we deploy this application.