### PR TITLE
member-management-client: GET members on page-load

### DIFF
--- a/services/member-management-client/src/index.js
+++ b/services/member-management-client/src/index.js
@@ -1,7 +1,19 @@
 import ReactDOM from 'react-dom';
 import React, { Fragment } from 'react';
+import * as MembersService from './members-service';
 
 class MemberManagementPage extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {};
+  }
+
+  componentDidMount() {
+    MembersService.getMembers().then(
+      (members) => this.setState({ members })
+    );
+  }
+
   render() {
     return (
       <Fragment>
@@ -17,23 +29,7 @@ class MemberManagementPage extends React.Component {
                 members
               </h2>
             </header>
-            <ul>
-              <li>
-                <button>delete</button>
-                <button>edit</button>
-                <span>olga rios</span>
-              </li>
-              <li>
-                <button>delete</button>
-                <button>edit</button>
-                <span>mitchell simpson</span>
-              </li>
-              <li>
-                <button>delete</button>
-                <button>edit</button>
-                <span>gwendolyn carlson</span>
-              </li>
-            </ul>
+            <Members members={this.state.members} />
             <footer>
               <button>add member</button>
             </footer>
@@ -42,6 +38,30 @@ class MemberManagementPage extends React.Component {
       </Fragment>
     )
   }
+}
+
+function Members({ members }) {
+  if (members === undefined) return null;
+
+  return (
+    <ul>
+      {
+        members.map(
+          ({ name }) => <Member name={name} />
+        )
+      }
+    </ul>
+  );
+}
+
+function Member({ name }) {
+  return (
+    <li>
+      <button>delete</button>
+      <button>edit</button>
+      <span>{name}</span>
+    </li>
+  );
 }
 
 ReactDOM.render(<MemberManagementPage />, document.getElementById('root'));

--- a/services/member-management-client/src/members-service.js
+++ b/services/member-management-client/src/members-service.js
@@ -1,0 +1,14 @@
+const SERVICE_URL = 'http://127.0.0.1:3000';
+
+export function getMembers() {
+  return fetch(`${SERVICE_URL}/members`, {
+    mode: 'cors',
+    method: 'get',
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    })
+  }).then(
+    (response) => response.json()
+  );
+}


### PR DESCRIPTION
# What's changed?

With the `member-management-client` running locally on port `3001` and the `members-service` running locally on port `3000` (after merging #16) we are now able to fetch members on page-load.

UI |
--- |
![image](https://user-images.githubusercontent.com/13058213/45645888-c3b5fc80-bab9-11e8-9274-e0565d5169df.png)
