### PR TITLE
member-management-client: Add ability to create members

### DIFF
--- a/services/member-management-client/src/index.js
+++ b/services/member-management-client/src/index.js
@@ -14,6 +14,12 @@ class MemberManagementPage extends React.Component {
     );
   }
 
+  handleSaveMember(member) {
+    this.setState({
+      members: this.state.members.concat([member])
+    });
+  }
+
   render() {
     return (
       <Fragment>
@@ -30,13 +36,81 @@ class MemberManagementPage extends React.Component {
               </h2>
             </header>
             <Members members={this.state.members} />
-            <footer>
-              <button>add member</button>
-            </footer>
+          </section>
+          <section>
+            <h2>
+              new member
+            </h2>
+            <MemberForm onSave={this.handleSaveMember.bind(this)}/>
           </section>
         </main>
       </Fragment>
     )
+  }
+}
+
+class MemberForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      original: {
+        name: props.member.name,
+      },
+      current: {
+        name: props.member.name,
+      }
+    };
+  }
+
+  static defaultProps = {
+    member: {
+      name: ''
+    }
+  };
+
+  handleSubmit(event) {
+    const { current, original } = this.state;
+
+    MembersService.createMember(current).then(
+      (member) => {
+        this.props.onSave(member);
+        this.setState({ current: original });
+      }
+    );
+
+    event.preventDefault();
+  }
+
+  handleNameChange(event) {
+    const name = event.target.value;
+
+    this.setState({ current: { name } });
+  }
+
+  handleReset(event) {
+    const original = this.state.original;
+
+    this.setState({ current: original });
+  }
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit.bind(this)} onReset={this.handleReset.bind(this)}>
+        <label>
+          <span>
+            name
+          </span>
+          <input type='text' value={this.state.current.name} onChange={this.handleNameChange.bind(this)} />
+        </label>
+        <button type='submit'>
+          save
+        </button>
+        <button type='reset'>
+          cancel
+        </button>
+      </form>
+    );
   }
 }
 

--- a/services/member-management-client/src/members-service.js
+++ b/services/member-management-client/src/members-service.js
@@ -12,3 +12,19 @@ export function getMembers() {
     (response) => response.json()
   );
 }
+
+export function createMember({ name }) {
+  return fetch(`${SERVICE_URL}/members`, {
+    mode: 'cors',
+    method: 'post',
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }),
+    body: JSON.stringify({
+      name
+    })
+  }).then(
+    (response) => response.json()
+  );
+}


### PR DESCRIPTION
# What's changed?

Add ability to create members through a UI.

At the moment the `members-service` API returns a hard-coded value (`"{ 'id': 1, 'name': 'Olga Rios' }"`) for the newly created member to allow building on top of API expectations. This will change to returning the newly created member in follow-on iterations.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/45648596-ea2b6600-bac0-11e8-8027-b26f483e5e56.png) |![after](https://user-images.githubusercontent.com/13058213/45648566-d4b63c00-bac0-11e8-979b-0a2ab3ae3f10.gif)

- [ ] member-management-service (v0)
  - [x] interface sketch
  - [ ] create, read, update and delete members using the members-service api (in progress)
  - [ ] docker
  - [ ] tests
  - [ ] configuration
  - [ ] documentation
  - [ ] deployment
  - [ ] token-based access control
