### PR TITLE
member-management-client: Add the ability to delete members

### DIFF
--- a/services/member-management-client/src/index.js
+++ b/services/member-management-client/src/index.js
@@ -20,6 +20,12 @@ class MemberManagementPage extends React.Component {
     });
   }
 
+  handleDeleteMember(id) {
+    this.setState({
+      members: this.state.members.filter((member) => id !== member.id)
+    });
+  }
+
   render() {
     return (
       <Fragment>
@@ -35,7 +41,7 @@ class MemberManagementPage extends React.Component {
                 members
               </h2>
             </header>
-            <Members members={this.state.members} />
+            <Members onDelete={this.handleDeleteMember.bind(this)} members={this.state.members} />
           </section>
           <section>
             <h2>
@@ -114,28 +120,36 @@ class MemberForm extends React.Component {
   }
 }
 
-function Members({ members }) {
+function Members({ onDelete, members }) {
   if (members === undefined) return null;
 
   return (
     <ul>
       {
         members.map(
-          ({ name }) => <Member name={name} />
+          ({ id, name }) => <Member key={id} id={id} name={name} onDelete={onDelete} />
         )
       }
     </ul>
   );
 }
 
-function Member({ name }) {
-  return (
-    <li>
-      <button>delete</button>
-      <button>edit</button>
-      <span>{name}</span>
-    </li>
-  );
+class Member extends React.Component {
+  handleDeleteMember() {
+    MembersService.deleteMember(this.props.id).then(
+      () => this.props.onDelete(this.props.id)
+    );
+  }
+
+  render() {
+    return (
+      <li>
+        <button onClick={this.handleDeleteMember.bind(this)}>delete</button>
+        <button>edit</button>
+        <span>{this.props.name}</span>
+      </li>
+    );
+  }
 }
 
 ReactDOM.render(<MemberManagementPage />, document.getElementById('root'));

--- a/services/member-management-client/src/members-service.js
+++ b/services/member-management-client/src/members-service.js
@@ -28,3 +28,14 @@ export function createMember({ name }) {
     (response) => response.json()
   );
 }
+
+export function deleteMember(id) {
+  return fetch(`${SERVICE_URL}/members/${id}`, {
+    mode: 'cors',
+    method: 'delete',
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }),
+  });
+}


### PR DESCRIPTION
# What's changed?

Add the ability to delete members.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/13058213/45653819-38486580-bad1-11e8-8973-fa2f12b21348.gif) | ![after](https://user-images.githubusercontent.com/13058213/45653820-38e0fc00-bad1-11e8-9153-4350746398d4.gif)

- [ ] member-management-client (v0)
  - [x] interface sketch
  - [ ] create, read, update and delete members using the members-service api (in progress)
  - [ ] docker
  - [ ] tests
  - [ ] configuration
  - [ ] documentation
  - [ ] deployment
  - [ ] token-based access control