### PR TITLE
member-management-client: Add ability to update member

### DIFF
--- a/services/member-management-client/src/index.js
+++ b/services/member-management-client/src/index.js
@@ -20,6 +20,12 @@ class MemberManagementPage extends React.Component {
     });
   }
 
+  handleUpdateMember(id, { name }) {
+    this.setState({
+      members: this.state.members.map((member) => member.id !== id ? member : { id, name })
+    })
+  }
+
   handleDeleteMember(id) {
     this.setState({
       members: this.state.members.filter((member) => id !== member.id)
@@ -41,13 +47,13 @@ class MemberManagementPage extends React.Component {
                 members
               </h2>
             </header>
-            <Members onDelete={this.handleDeleteMember.bind(this)} members={this.state.members} />
+            <Members onUpdate={this.handleUpdateMember.bind(this)} onDelete={this.handleDeleteMember.bind(this)} members={this.state.members} />
           </section>
           <section>
             <h2>
               new member
             </h2>
-            <MemberForm onSave={this.handleSaveMember.bind(this)}/>
+            <NewMemberForm onSave={this.handleSaveMember.bind(this)}/>
           </section>
         </main>
       </Fragment>
@@ -55,7 +61,7 @@ class MemberManagementPage extends React.Component {
   }
 }
 
-class MemberForm extends React.Component {
+class NewMemberForm extends React.Component {
   constructor(props) {
     super(props);
 
@@ -120,14 +126,75 @@ class MemberForm extends React.Component {
   }
 }
 
-function Members({ onDelete, members }) {
+class EditMemberForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      original: {
+        name: props.member.name,
+      },
+      current: {
+        name: props.member.name,
+      }
+    };
+  }
+
+  handleSubmit(event) {
+    const { current, original } = this.state;
+
+    MembersService.updateMember(this.props.member.id, current).then(
+      (member) => {
+        this.props.onSave(this.props.member.id, member);
+        this.setState({ current: original });
+      }
+    );
+
+    event.preventDefault();
+  }
+
+  handleNameChange(event) {
+    const name = event.target.value;
+
+    this.setState({ current: { name } });
+  }
+
+  handleReset(event) {
+    const original = this.state.original;
+
+    this.setState({ current: original });
+
+    this.props.onCancel();
+  }
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit.bind(this)} onReset={this.handleReset.bind(this)}>
+        <label>
+          <span>
+            name
+          </span>
+          <input type='text' value={this.state.current.name} onChange={this.handleNameChange.bind(this)} />
+        </label>
+        <button type='submit'>
+          save
+        </button>
+        <button type='reset'>
+          cancel
+        </button>
+      </form>
+    );
+  }
+}
+
+function Members({ onUpdate, onDelete, members }) {
   if (members === undefined) return null;
 
   return (
     <ul>
       {
         members.map(
-          ({ id, name }) => <Member key={id} id={id} name={name} onDelete={onDelete} />
+          (member) => <Member key={member.id} member={member} onUpdate={onUpdate} onDelete={onDelete} />
         )
       }
     </ul>
@@ -135,18 +202,42 @@ function Members({ onDelete, members }) {
 }
 
 class Member extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { editing: false };
+  }
+
   handleDeleteMember() {
     MembersService.deleteMember(this.props.id).then(
       () => this.props.onDelete(this.props.id)
     );
   }
 
+  handleEditMember() {
+    this.setState({ editing: true });
+  }
+
+  handleUpdateMember(id, member) {
+    this.props.onUpdate(id, member);
+    this.setState({ editing: false });
+  }
+
+  handleReset() {
+    this.setState({ editing: false });
+  }
+
   render() {
+    if (this.state.editing) return (
+      <li>
+        <EditMemberForm onCancel={this.handleReset.bind(this)} onSave={this.handleUpdateMember.bind(this)} member={this.props.member} />
+      </li>
+    );
+
     return (
       <li>
         <button onClick={this.handleDeleteMember.bind(this)}>delete</button>
-        <button>edit</button>
-        <span>{this.props.name}</span>
+        <button onClick={this.handleEditMember.bind(this)}>edit</button>
+        <span>{this.props.member.name}</span>
       </li>
     );
   }

--- a/services/member-management-client/src/members-service.js
+++ b/services/member-management-client/src/members-service.js
@@ -29,6 +29,22 @@ export function createMember({ name }) {
   );
 }
 
+export function updateMember(id, { name }) {
+  return fetch(`${SERVICE_URL}/members/${id}`, {
+    mode: 'cors',
+    method: 'put',
+    headers: new Headers({
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }),
+    body: JSON.stringify({
+      name
+    })
+  }).then(
+    (response) => response.json()
+  );
+}
+
 export function deleteMember(id) {
   return fetch(`${SERVICE_URL}/members/${id}`, {
     mode: 'cors',


### PR DESCRIPTION
# What's changed?

Add ability to update member.

The code is getting messy now, but that's okay. Now that the foundational C.R.U.D. functionality is in place, we are in a good place to decide what the UI should look like and refactor accordingly.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/13058213/45656475-a561f800-badd-11e8-9b6f-a5435969987a.gif) | ![after](https://user-images.githubusercontent.com/13058213/45656478-a72bbb80-badd-11e8-930f-12b5521bbe17.gif)

- [ ] member-management-client (v0)
  - [x] interface sketch
  - [x] create, read, update and delete members using the members-service api
  - [ ] docker
  - [ ] tests
  - [ ] configuration
  - [ ] documentation
  - [ ] deployment
  - [ ] token-based access control