### PR TITLE
member-management-client: Bugfix deleting members

### DIFF
--- a/services/member-management-client/src/index.js
+++ b/services/member-management-client/src/index.js
@@ -208,8 +208,8 @@ class Member extends React.Component {
   }
 
   handleDeleteMember() {
-    MembersService.deleteMember(this.props.id).then(
-      () => this.props.onDelete(this.props.id)
+    MembersService.deleteMember(this.props.member.id).then(
+      () => this.props.onDelete(this.props.member.id)
     );
   }
 


### PR DESCRIPTION
# What's changed?

We are now passing a `member` prop, rather than passing `name` and `id` separately. However, I forgot to make this change for the deletion logic, when introducing the ability to update members.

Tested C.R.U.D. manually.