### PR TITLE
members-service: Add database integration with PostgreSQL

### DIFF
--- a/services/members-service/Pipfile
+++ b/services/members-service/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 flask = "*"
 flask-cors = "*"
+flask-sqlalchemy = "*"
+"psycopg2" = "*"
 
 [dev-packages]
 

--- a/services/members-service/Pipfile.lock
+++ b/services/members-service/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3890472530731f0c50bf092eb0abea76e7b92ca13f1d370f9714a0957de35dee"
+            "sha256": "58670c99a49f56f3caadb5eab457770142df18a52b480131706000ca46a494b1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,14 @@
             "index": "pypi",
             "version": "==3.0.6"
         },
+        "flask-sqlalchemy": {
+            "hashes": [
+                "sha256:3bc0fac969dd8c0ace01b32060f0c729565293302f0c4269beed154b46bec50b",
+                "sha256:5971b9852b5888655f11db634e87725a9031e170f37c0ce7851cf83497f56e53"
+            ],
+            "index": "pypi",
+            "version": "==2.3.2"
+        },
         "itsdangerous": {
             "hashes": [
                 "sha256:cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519"
@@ -58,12 +66,54 @@
             ],
             "version": "==1.0"
         },
+        "psycopg2": {
+            "hashes": [
+                "sha256:0b9e48a1c1505699a64ac58815ca99104aacace8321e455072cee4f7fe7b2698",
+                "sha256:0f4c784e1b5a320efb434c66a50b8dd7e30a7dc047e8f45c0a8d2694bfe72781",
+                "sha256:0fdbaa32c9eb09ef09d425dc154628fca6fa69d2f7c1a33f889abb7e0efb3909",
+                "sha256:11fbf688d5c953c0a5ba625cc42dea9aeb2321942c7c5ed9341a68f865dc8cb1",
+                "sha256:19eaac4eb25ab078bd0f28304a0cb08702d120caadfe76bb1e6846ed1f68635e",
+                "sha256:3232ec1a3bf4dba97fbf9b03ce12e4b6c1d01ea3c85773903a67ced725728232",
+                "sha256:36f8f9c216fcca048006f6dd60e4d3e6f406afde26cfb99e063f137070139eaf",
+                "sha256:59c1a0e4f9abe970062ed35d0720935197800a7ef7a62b3a9e3a70588d9ca40b",
+                "sha256:6506c5ff88750948c28d41852c09c5d2a49f51f28c6d90cbf1b6808e18c64e88",
+                "sha256:6bc3e68ee16f571681b8c0b6d5c0a77bef3c589012352b3f0cf5520e674e9d01",
+                "sha256:6dbbd7aabbc861eec6b910522534894d9dbb507d5819bc982032c3ea2e974f51",
+                "sha256:6e737915de826650d1a5f7ff4ac6cf888a26f021a647390ca7bafdba0e85462b",
+                "sha256:6ed9b2cfe85abc720e8943c1808eeffd41daa73e18b7c1e1a228b0b91f768ccc",
+                "sha256:711ec617ba453fdfc66616db2520db3a6d9a891e3bf62ef9aba4c95bb4e61230",
+                "sha256:844dacdf7530c5c612718cf12bc001f59b2d9329d35b495f1ff25045161aa6af",
+                "sha256:86b52e146da13c896e50c5a3341a9448151f1092b1a4153e425d1e8b62fec508",
+                "sha256:985c06c2a0f227131733ae58d6a541a5bc8b665e7305494782bebdb74202b793",
+                "sha256:a86dfe45f4f9c55b1a2312ff20a59b30da8d39c0e8821d00018372a2a177098f",
+                "sha256:aa3cd07f7f7e3183b63d48300666f920828a9dbd7d7ec53d450df2c4953687a9",
+                "sha256:b1964ed645ef8317806d615d9ff006c0dadc09dfc54b99ae67f9ba7a1ec9d5d2",
+                "sha256:b2abbff9e4141484bb89b96eb8eae186d77bc6d5ffbec6b01783ee5c3c467351",
+                "sha256:cc33c3a90492e21713260095f02b12bee02b8d1f2c03a221d763ce04fa90e2e9",
+                "sha256:d7de3bf0986d777807611c36e809b77a13bf1888f5c8db0ebf24b47a52d10726",
+                "sha256:db5e3c52576cc5b93a959a03ccc3b02cb8f0af1fbbdc80645f7a215f0b864f3a",
+                "sha256:e168aa795ffbb11379c942cf95bf813c7db9aa55538eb61de8c6815e092416f5",
+                "sha256:e9ca911f8e2d3117e5241d5fa9aaa991cb22fb0792627eeada47425d706b5ec8",
+                "sha256:eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e",
+                "sha256:efa19deae6b9e504a74347fe5e25c2cb9343766c489c2ae921b05f37338b18d1",
+                "sha256:f4b0460a21f784abe17b496f66e74157a6c36116fa86da8bf6aa028b9e8ad5fe",
+                "sha256:f93d508ca64d924d478fb11e272e09524698f0c581d9032e68958cfbdd41faef"
+            ],
+            "index": "pypi",
+            "version": "==2.7.5"
+        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524"
+            ],
+            "version": "==1.2.11"
         },
         "werkzeug": {
             "hashes": [

--- a/services/members-service/application.py
+++ b/services/members-service/application.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+from flask_sqlalchemy import SQLAlchemy
 
 
 application = Flask(__name__)
@@ -8,19 +9,60 @@ application = Flask(__name__)
 CORS(application)
 
 
+application.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql+psycopg2://postgres:@localhost:5432/members'
+
+
+database = SQLAlchemy(application)
+
+class Member(database.Model):
+    id = database.Column(database.Integer, primary_key=True)
+    name = database.Column(database.String)
+
+    def __repr__(self):
+        return '<Member(id=%i name=%s)>' % (self.id, self.name)
+
+    def serialize(self):
+        return { 'id': self.id, 'name': self.name }
+
+database.create_all()
+
+
 @application.route('/members', methods=['GET', 'POST'])
 def members():
     if request.method == 'GET':
-        return jsonify([{ 'id': 1, 'name': 'Olga Rios' }, { 'id': 2, 'name': 'Mitchell Simpson' }]), 200
+        members = Member.query.all()
+
+        return jsonify([member.serialize() for member in members]), 200
     elif request.method == 'POST':
-        return jsonify({ 'id': 1, 'name': 'Olga Rios' }), 201
+        name = request.json.get('name', 'No name')
+
+        member = Member(name=name)
+
+        database.session.add(member)
+        database.session.commit()
+
+        return jsonify(member.serialize()), 201
 
 
 @application.route('/members/<int:member_id>', methods=['PUT', 'DELETE'])
 def member(member_id):
     if request.method == 'PUT':
-        return jsonify({ 'id': member_id, 'name': 'Gwendolyn Carlson' }), 200
+        name = request.json.get('name', 'No name')
+
+        member = Member.query.get(member_id)
+
+        member.name = name
+
+        database.session.add(member)
+        database.session.commit()
+
+        return jsonify(member.serialize()), 200
     elif request.method == 'DELETE':
+        member = Member.query.get(member_id)
+
+        database.session.delete(member)
+        database.session.commit()
+
         return jsonify(None), 204
 
 


### PR DESCRIPTION
# What's changed?

Add database integration with a locally running PostgreSQL instance.

Having this shabby database integration facilitates having an end-to-end flow for C.R.U.D. operations on members between the `member-management-client` and the `members-service` and should be enough to get some early feedback on the direction of development.

C.R.U.D. |
--- |
![after](https://user-images.githubusercontent.com/13058213/45724908-2ab5dd00-bbb0-11e8-9e43-9e06086ac2e4.gif)

- [ ] members-service
  - [x] api sketch
  - [x] database
  - [ ] get feedback 🎉 
  - [ ] configuration
  - [ ] docker
  - [ ] tests
  - [ ] documentation
  - [ ] deployment
  - [ ] token-based access control
  - [ ] cross-origin access control policy